### PR TITLE
Missing 'setContentOffset' declaration in IIMyScene header file.

### DIFF
--- a/ScrollKit/IIMyScene.h
+++ b/ScrollKit/IIMyScene.h
@@ -17,5 +17,6 @@
 @property(nonatomic) CGPoint contentOffset;
 
 -(void)setContentScale:(CGFloat)scale;
+-(void)setContentOffset:(CGPoint)contentOffset;
 
 @end


### PR DESCRIPTION
Added in the missing method. It is called inside the ViewController, and isn't declared in the header file.